### PR TITLE
CaptainDuckDuck Configuration File

### DIFF
--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "dockerfileLines": [
+    "FROM node:carbon-alpine",
+    "WORKDIR /usr/src/server",
+    "ENV TINI_VERSION v0.16.1",
+    "ENV PORT 3000",
+    "ENV NODE_ENV production",
+    "ENV UCLAPI_CLIENT_ID \"\"",
+    "ENV UCLAPI_CLIENT_SECRET \"\"",
+    "ENV SECRET \"\"",
+    "RUN apk add --no-cache tini",
+    "ENTRYPOINT [\"/sbin/tini\", \"--\"]",
+    "COPY api/package.json ./",
+    "COPY api/yarn.lock ./",
+    "RUN yarn install --pure-lockfile",
+    "COPY api/ .",
+    "EXPOSE ${PORT}",
+    "USER node",
+    "CMD [ \"/usr/local/bin/yarn\", \"start\" ]"
+  ]
+}


### PR DESCRIPTION
This will get the API running. All environment variables have been removed compared to the Dockerfile because they are managed from within Captain.

The ./src directory is created by Captain, and therefore does not exist here.